### PR TITLE
[MAT-7570] Limit date shift results to [0, 9999]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>gov.cms.madie</groupId>
   <artifactId>madie-java-models</artifactId>
-  <version>0.6.58-SNAPSHOT</version>
+  <version>0.6.59-SNAPSHOT</version>
   <name>madie-java-models</name>
   <description>Java based models for MADiE microservices</description>
   <properties>

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/basetypes/DataElement.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/basetypes/DataElement.java
@@ -117,10 +117,10 @@ public class DataElement {
       return null;
     }
     if (interval.getLow() != null) {
-      interval.setLow(interval.getLow().plusYears(year));
+      interval.setLow(shiftDateByYear(interval.getLow(), year));
     }
     if (interval.getHigh() != null) {
-      interval.setHigh(interval.getHigh().plusYears(year));
+      interval.setHigh(shiftDateByYear(interval.getHigh(), year));
     }
     return interval;
   }
@@ -129,6 +129,13 @@ public class DataElement {
     if (dateTime == null) {
       return null;
     }
-    return dateTime.plusYears(year);
+    ZonedDateTime shiftedDateTime = dateTime.plusYears(year);
+    if (shiftedDateTime.getYear() > 9999) {
+      return shiftedDateTime.withYear(9999);
+    }
+    if (shiftedDateTime.getYear() < 0) {
+      return shiftedDateTime.withYear(0);
+    }
+    return shiftedDateTime;
   }
 }

--- a/src/test/java/gov/cms/madie/models/cqm/datacriteria/basetypes/DataElementTest.java
+++ b/src/test/java/gov/cms/madie/models/cqm/datacriteria/basetypes/DataElementTest.java
@@ -1,0 +1,31 @@
+package gov.cms.madie.models.cqm.datacriteria.basetypes;
+
+import gov.cms.madie.models.cqm.datacriteria.EncounterPerformed;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DataElementTest {
+
+  @Test
+  void shiftDateByYearAfterYear9999() {
+    EncounterPerformed encounterPerformed = new EncounterPerformed();
+    ZonedDateTime dateTime = ZonedDateTime.ofInstant(Instant.now(), ZoneId.of("UTC"));
+    encounterPerformed.setAuthorDatetime(dateTime);
+    ZonedDateTime shiftedDateTime = encounterPerformed.shiftDateByYear(dateTime, 100000);
+    assertThat(shiftedDateTime).isEqualTo(dateTime.withYear(9999));
+  }
+
+  @Test
+  void shiftDateByYearBeforeYear0() {
+    EncounterPerformed encounterPerformed = new EncounterPerformed();
+    ZonedDateTime dateTime = ZonedDateTime.ofInstant(Instant.now(), ZoneId.of("UTC"));
+    encounterPerformed.setAuthorDatetime(dateTime);
+    ZonedDateTime shiftedDateTime = encounterPerformed.shiftDateByYear(dateTime, -100000);
+    assertThat(shiftedDateTime).isEqualTo(dateTime.withYear(0));
+  }
+}


### PR DESCRIPTION
## MADiE PR Template

Jira Ticket: [MAT-7570](https://jira.cms.gov/browse/MAT-7570)
(Optional) Related Tickets:

### Summary

Java Time handles years beyond [0, 9999], but our tech stack does not. At this time, it is not beneficial to users to be able to work with years outside the above range, hence setting this limit to make our lives easier.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e. Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
