### PR TITLE
[MAT-7437] Enforce non-blank Improvement Notation Description for QDM Measures when Improvement Notation is set to 'Other'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>gov.cms.madie</groupId>
   <artifactId>madie-java-models</artifactId>
-  <version>0.6.65-SNAPSHOT</version>
+  <version>0.6.66-SNAPSHOT</version>
   <name>madie-java-models</name>
   <description>Java based models for MADiE microservices</description>
   <properties>
@@ -71,6 +71,11 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${fasterxml.jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.17.0</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/gov/cms/madie/models/measure/QdmMeasure.java
+++ b/src/main/java/gov/cms/madie/models/measure/QdmMeasure.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import gov.cms.madie.models.validators.ValidMeasureScoring;
+import gov.cms.madie.models.validators.ValidOtherImprovementNotation;
 import gov.cms.madie.models.validators.ValidQDMGroupScoring;
 import lombok.Builder;
 import lombok.Data;
@@ -18,6 +19,7 @@ import lombok.experimental.SuperBuilder;
 @ToString(callSuper = true)
 @ValidMeasureScoring
 @ValidQDMGroupScoring
+@ValidOtherImprovementNotation
 public class QdmMeasure extends Measure {
 
   private String scoring;

--- a/src/main/java/gov/cms/madie/models/validators/OtherImprovementNotationValidator.java
+++ b/src/main/java/gov/cms/madie/models/validators/OtherImprovementNotationValidator.java
@@ -1,0 +1,20 @@
+package gov.cms.madie.models.validators;
+
+import gov.cms.madie.models.measure.*;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+@Slf4j
+public class OtherImprovementNotationValidator
+    implements ConstraintValidator<ValidOtherImprovementNotation, QdmMeasure> {
+
+  @Override
+  public boolean isValid(QdmMeasure measure, ConstraintValidatorContext context) {
+    if (StringUtils.equalsIgnoreCase(measure.getImprovementNotation(), "Other")) {
+      return StringUtils.isNotBlank(measure.getImprovementNotationDescription());
+    }
+    return true;
+  }
+}

--- a/src/main/java/gov/cms/madie/models/validators/ValidOtherImprovementNotation.java
+++ b/src/main/java/gov/cms/madie/models/validators/ValidOtherImprovementNotation.java
@@ -1,0 +1,19 @@
+package gov.cms.madie.models.validators;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = OtherImprovementNotationValidator.class)
+@Documented
+public @interface ValidOtherImprovementNotation {
+
+  String message() default "Improvement Notation Description is required when Other is selected";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}


### PR DESCRIPTION
## MADiE PR Template

Jira Ticket: [MAT-7437](https://jira.cms.gov/browse/MAT-7437)
(Optional) Related Tickets:

### Summary

For QDM Measures, when Improvement Notation is 'Other', require the related Description field to not be blank.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e. Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
