### PR TITLE
MAT-7980: Move Scoring Precision to the Pop Criteria obj and restrict to positive int only.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>gov.cms.madie</groupId>
   <artifactId>madie-java-models</artifactId>
-  <version>0.6.74-SNAPSHOT</version>
+  <version>0.6.75-SNAPSHOT</version>
   <name>madie-java-models</name>
   <description>Java based models for MADiE microservices</description>
   <properties>

--- a/src/main/java/gov/cms/madie/models/measure/FhirMeasure.java
+++ b/src/main/java/gov/cms/madie/models/measure/FhirMeasure.java
@@ -14,6 +14,4 @@ import lombok.experimental.SuperBuilder;
 @JsonTypeName("QI-Core v4.1.1")
 @ToString(callSuper = true)
 @ValidFhirGroup
-public class FhirMeasure extends Measure {
-  private Integer scoringPrecision;
-}
+public class FhirMeasure extends Measure {}

--- a/src/main/java/gov/cms/madie/models/measure/Group.java
+++ b/src/main/java/gov/cms/madie/models/measure/Group.java
@@ -3,6 +3,7 @@ package gov.cms.madie.models.measure;
 import gov.cms.madie.models.validators.EnumValidator;
 import gov.cms.madie.models.validators.ValidGroupScoringPopulation;
 import gov.cms.madie.models.validators.ValidMeasureObservation;
+import jakarta.validation.constraints.Min;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -51,4 +52,7 @@ public class Group implements GroupScoringPopulation {
   @Valid private List<Stratification> stratifications;
 
   private String populationBasis;
+
+  @Min(1)
+  private Integer scoringPrecision;
 }


### PR DESCRIPTION
## MADiE PR Template

Jira Ticket: [MAT-7980](https://jira.cms.gov/browse/MAT-7980)
(Optional) Related Tickets:

### Summary

Corrections for MAT-7980. ScoringPrecision can be saved to either the Measure root or Measure.group (aka Population Criteria). This refactor moves the field from root to Measure.group and adds validation for positive int only.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e. Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
