### PR TITLE
Update automated-codejson-generator to @main

### DIFF
--- a/.github/workflows/updateCodeJSON.yml
+++ b/.github/workflows/updateCodeJSON.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Update code.json
-        uses: DSACMS/automated-codejson-generator@v1.0.1
+        uses: DSACMS/automated-codejson-generator@v1.2.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: "develop"

--- a/.github/workflows/updateCodeJSON.yml
+++ b/.github/workflows/updateCodeJSON.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Update code.json
-        uses: DSACMS/automated-codejson-generator@v1.2.1
+        uses: DSACMS/automated-codejson-generator@main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: "develop"


### PR DESCRIPTION
### Hello from the Open Source Program Office team!

The current version you are running is causing the job to fail and bumping up the version to **@main** will remedy this. 
Thank you for using this tool! If you have any questions, please feel free to email us at opensource@cms.hhs.gov.