### PR TITLE
MAT-10132: update spring boot (from 3.5.14 to 4.0.7)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>gov.cms.madie</groupId>
   <artifactId>madie-java-models</artifactId>
-  <version>0.9.7-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
   <name>madie-java-models</name>
   <description>Java based models for MADiE microservices</description>
   <properties>
@@ -16,8 +16,7 @@
     <mvn.checkstyle.version>3.3.0</mvn.checkstyle.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <fasterxml.jackson.version>2.21.2</fasterxml.jackson.version>
-    <springboot.version>3.5.14</springboot.version>
+    <springboot.version>4.0.6</springboot.version>
   </properties>
 
   <distributionManagement>
@@ -27,6 +26,18 @@
       <url>https://maven.pkg.github.com/measureauthoringtool/madie-java-models</url>
     </repository>
   </distributionManagement>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${springboot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -53,6 +64,11 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-jackson</artifactId>
+      <version>${springboot.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-mongodb</artifactId>
       <version>${springboot.version}</version>
     </dependency>
@@ -65,12 +81,10 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.21</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${fasterxml.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -98,7 +112,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.1</version>
+          <version>3.5.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <mvn.checkstyle.version>3.3.0</mvn.checkstyle.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <springboot.version>4.0.6</springboot.version>
+    <springboot.version>4.0.7</springboot.version>
   </properties>
 
   <distributionManagement>

--- a/src/main/java/gov/cms/madie/models/common/ModelType.java
+++ b/src/main/java/gov/cms/madie/models/common/ModelType.java
@@ -15,7 +15,7 @@ public enum ModelType {
   QI_CORE_6_0_0(VersionConstants.QICORE_6_0_0_VERSION, "qicore6"),
   QI_CORE_7_0_0(VersionConstants.QICORE_7_0_0_VERSION, "qicore7"),
   QI_CORE_7_0_2(VersionConstants.QICORE_7_0_2_VERSION, "qicore7"),
-  US_CORE_6_0_1(VersionConstants.US_CORE_6_1_0_VERSION, "uscore6"),
+  US_CORE_6_1_0(VersionConstants.US_CORE_6_1_0_VERSION, "uscore6"),
   US_QUALITY_CORE_0_5_0(VersionConstants.USQUALITYCORE_0_5_0_Version, "usqualitycore05"),
   QDM_5_6(VersionConstants.QDM_5_6_VERSION, "qdm");
 

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/AdverseEvent.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/AdverseEvent.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -46,6 +48,8 @@ public class AdverseEvent extends DataElement {
   private String hqmfOid = "2.16.840.1.113883.10.20.28.4.120";
   private String qdmCategory = "adverse_event";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::AdverseEvent";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/AllergyIntolerance.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/AllergyIntolerance.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.Code;
@@ -41,6 +43,8 @@ public class AllergyIntolerance extends DataElement {
   private String qdmCategory = "allergy";
   private String qdmStatus = "intolerance";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::AllergyIntolerance";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/AssessmentOrder.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/AssessmentOrder.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -39,6 +41,8 @@ public class AssessmentOrder extends DataElement {
   private String qdmCategory = "assessment";
   private String qdmStatus = "order";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::AssessmentOrder";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/AssessmentPerformed.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/AssessmentPerformed.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.Code;
@@ -54,6 +56,8 @@ public class AssessmentPerformed extends DataElement {
   private String qdmCategory = "assessment";
   private String qdmStatus = "performed";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::AssessmentPerformed";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/AssessmentRecommended.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/AssessmentRecommended.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -39,6 +41,8 @@ public class AssessmentRecommended extends DataElement {
   private String qdmCategory = "assessment";
   private String qdmStatus = "recommended";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::AssessmentRecommended";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/CareGoal.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/CareGoal.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.Interval;
@@ -37,6 +39,8 @@ public class CareGoal extends DataElement {
   private String hqmfOid = "2.16.840.1.113883.10.20.28.4.7";
   private String qdmCategory = "care_goal";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::CareGoal";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/CommunicationPerformed.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/CommunicationPerformed.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -55,6 +57,8 @@ public class CommunicationPerformed extends DataElement {
   private String qdmCategory = "communication";
   private String qdmStatus = "performed";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::CommunicationPerformed";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/DeviceOrder.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/DeviceOrder.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -39,6 +41,8 @@ public class DeviceOrder extends DataElement {
   private String qdmCategory = "device";
   private String qdmStatus = "order";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::DeviceOrder";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/DeviceRecommended.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/DeviceRecommended.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -39,6 +41,8 @@ public class DeviceRecommended extends DataElement {
   private String qdmCategory = "device";
   private String qdmStatus = "recommended";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::DeviceRecommended";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/Diagnosis.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/Diagnosis.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.Code;
@@ -41,6 +43,8 @@ public class Diagnosis extends DataElement {
   private String qrdaOid = "2.16.840.1.113883.10.20.24.3.135";
   private String qdmCategory = "condition";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::Diagnosis";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/DiagnosisComponent.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/DiagnosisComponent.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import gov.cms.madie.models.cqm.datacriteria.basetypes.Code;
@@ -15,8 +17,13 @@ import lombok.experimental.SuperBuilder;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DiagnosisComponent {
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::DiagnosisComponent";
+
+  @JsonProperty("_id")
   private String _id;
+
   private Code code;
   private Code presentOnAdmissionIndicator;
   private Integer rank;

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/DiagnosticStudyOrder.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/DiagnosticStudyOrder.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -39,6 +41,8 @@ public class DiagnosticStudyOrder extends DataElement {
   private String qdmCategory = "diagnostic_study";
   private String qdmStatus = "order";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::DiagnosticStudyOrder";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/DiagnosticStudyPerformed.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/DiagnosticStudyPerformed.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
 import gov.cms.madie.models.cqm.datacriteria.attributes.FacilityLocation;
@@ -64,6 +66,8 @@ public class DiagnosticStudyPerformed extends DataElement {
   private String qdmCategory = "diagnostic_study";
   private String qdmStatus = "performed";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::DiagnosticStudyPerformed";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/DiagnosticStudyRecommended.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/DiagnosticStudyRecommended.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -39,6 +41,8 @@ public class DiagnosticStudyRecommended extends DataElement {
   private String qdmCategory = "diagnostic_study";
   private String qdmStatus = "recommended";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::DiagnosticStudyRecommended";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/EncounterOrder.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/EncounterOrder.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -42,6 +44,8 @@ public class EncounterOrder extends DataElement {
   private String qdmCategory = "encounter";
   private String qdmStatus = "order";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::EncounterOrder";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/EncounterPerformed.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/EncounterPerformed.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
 import gov.cms.madie.models.cqm.datacriteria.attributes.FacilityLocation;
@@ -51,6 +53,8 @@ public class EncounterPerformed extends DataElement {
   private String qdmCategory = "encounter";
   private String qdmStatus = "performed";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::EncounterPerformed";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/EncounterRecommended.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/EncounterRecommended.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -41,6 +43,8 @@ public class EncounterRecommended extends DataElement {
   private String qdmCategory = "encounter";
   private String qdmStatus = "recommended";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::EncounterRecommended";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/FamilyHistory.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/FamilyHistory.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -38,6 +40,8 @@ public class FamilyHistory extends DataElement {
   private String qrdaOid = "2.16.840.1.113883.10.20.24.3.12";
   private String qdmCategory = "family_history";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::FamilyHistory";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/ImmunizationAdministered.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/ImmunizationAdministered.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -49,6 +51,8 @@ public class ImmunizationAdministered extends DataElement {
   private String qdmCategory = "immunization";
   private String qdmStatus = "administered";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::ImmunizationAdministered";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/ImmunizationOrder.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/ImmunizationOrder.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -49,6 +51,8 @@ public class ImmunizationOrder extends DataElement {
   private String qdmCategory = "immunization";
   private String qdmStatus = "order";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::ImmunizationOrder";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/InterventionOrder.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/InterventionOrder.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -39,6 +41,8 @@ public class InterventionOrder extends DataElement {
   private String qdmCategory = "intervention";
   private String qdmStatus = "order";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::InterventionOrder";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/InterventionPerformed.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/InterventionPerformed.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.Code;
@@ -50,6 +52,8 @@ public class InterventionPerformed extends DataElement {
   private String qdmCategory = "intervention";
   private String qdmStatus = "performed";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::InterventionPerformed";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/InterventionRecommended.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/InterventionRecommended.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -39,6 +41,8 @@ public class InterventionRecommended extends DataElement {
   private String qdmCategory = "intervention";
   private String qdmStatus = "recommended";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::InterventionRecommended";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/LaboratoryTestOrder.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/LaboratoryTestOrder.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -39,6 +41,8 @@ public class LaboratoryTestOrder extends DataElement {
   private String qdmCategory = "laboratory_test";
   private String qdmStatus = "order";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::LaboratoryTestOrder";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/LaboratoryTestPerformed.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/LaboratoryTestPerformed.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.Code;
@@ -66,6 +68,8 @@ public class LaboratoryTestPerformed extends DataElement {
   private String qdmCategory = "laboratory_test";
   private String qdmStatus = "performed";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::LaboratoryTestPerformed";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/LaboratoryTestRecommended.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/LaboratoryTestRecommended.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -39,6 +41,8 @@ public class LaboratoryTestRecommended extends DataElement {
   private String qdmCategory = "laboratory_test";
   private String qdmStatus = "recommended";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::LaboratoryTestRecommended";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/MedicationActive.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/MedicationActive.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.Code;
@@ -43,6 +45,8 @@ public class MedicationActive extends DataElement {
   private String qdmCategory = "medication";
   private String qdmStatus = "active";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::MedicationActive";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/MedicationAdministered.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/MedicationAdministered.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.Code;
@@ -51,6 +53,8 @@ public class MedicationAdministered extends DataElement {
   private String qdmCategory = "medication";
   private String qdmStatus = "administered";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::MedicationAdministered";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/MedicationDischarge.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/MedicationDischarge.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -46,6 +48,8 @@ public class MedicationDischarge extends DataElement {
   private String qdmCategory = "medication";
   private String qdmStatus = "discharge";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::MedicationDischarge";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/MedicationDispensed.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/MedicationDispensed.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.Code;
@@ -55,6 +57,8 @@ public class MedicationDispensed extends DataElement {
   private String qdmCategory = "medication";
   private String qdmStatus = "dispensed";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::MedicationDispensed";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/MedicationOrder.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/MedicationOrder.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.Code;
@@ -50,6 +52,8 @@ public class MedicationOrder extends DataElement {
   private String qdmCategory = "medication";
   private String qdmStatus = "order";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::MedicationOrder";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/Participation.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/Participation.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.Interval;
 import lombok.AllArgsConstructor;
@@ -17,6 +19,8 @@ public class Participation extends DataElement {
   private String hqmfOid = "2.16.840.1.113883.10.20.28.4.130";
   private String qdmCategory = "participation";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::Participation";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/PatientCareExperience.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/PatientCareExperience.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -35,6 +37,8 @@ public class PatientCareExperience extends DataElement {
   private String hqmfOid = "2.16.840.1.113883.10.20.28.4.52";
   private String qdmCategory = "care_experience";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::PatientCareExperience";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/PatientCharacteristic.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/PatientCharacteristic.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import lombok.AllArgsConstructor;
@@ -32,6 +34,8 @@ public class PatientCharacteristic extends DataElement {
   private String hqmfOid = "2.16.840.1.113883.10.20.28.4.53";
   private String qdmCategory = "patient_characteristic";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::PatientCharacteristic";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/PatientCharacteristicBirthdate.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/PatientCharacteristicBirthdate.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import lombok.AllArgsConstructor;
@@ -33,6 +35,8 @@ public class PatientCharacteristicBirthdate extends DataElement {
   private String qdmCategory = "patient_characteristic";
   private String qdmStatus = "birthdate";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::PatientCharacteristicBirthdate";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/PatientCharacteristicClinicalTrialParticipant.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/PatientCharacteristicClinicalTrialParticipant.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.Code;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.Interval;
@@ -25,6 +27,8 @@ public class PatientCharacteristicClinicalTrialParticipant extends DataElement {
   private String qdmCategory = "patient_characteristic";
   private String qdmStatus = "clinical_trial_participant";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::PatientCharacteristicClinicalTrialParticipant";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/PatientCharacteristicEthnicity.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/PatientCharacteristicEthnicity.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -16,6 +18,8 @@ public class PatientCharacteristicEthnicity extends DataElement {
   private String qdmCategory = "patient_characteristic";
   private String qdmStatus = "ethnicity";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::PatientCharacteristicEthnicity";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/PatientCharacteristicExpired.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/PatientCharacteristicExpired.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.Code;
@@ -35,6 +37,8 @@ public class PatientCharacteristicExpired extends DataElement {
   private String qdmCategory = "patient_characteristic";
   private String qdmStatus = "expired";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::PatientCharacteristicExpired";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/PatientCharacteristicPayer.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/PatientCharacteristicPayer.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.Interval;
 import lombok.AllArgsConstructor;
@@ -18,6 +20,8 @@ public class PatientCharacteristicPayer extends DataElement {
   private String qdmCategory = "patient_characteristic";
   private String qdmStatus = "payer";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::PatientCharacteristicPayer";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/PatientCharacteristicRace.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/PatientCharacteristicRace.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -16,6 +18,8 @@ public class PatientCharacteristicRace extends DataElement {
   private String qdmCategory = "patient_characteristic";
   private String qdmStatus = "race";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::PatientCharacteristicRace";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/PatientCharacteristicSex.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/PatientCharacteristicSex.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -16,6 +18,8 @@ public class PatientCharacteristicSex extends DataElement {
   private String qdmCategory = "patient_characteristic";
   private String qdmStatus = "gender";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::PatientCharacteristicSex";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/PhysicalExamOrder.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/PhysicalExamOrder.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -40,6 +42,8 @@ public class PhysicalExamOrder extends DataElement {
   private String qdmCategory = "physical_exam";
   private String qdmStatus = "order";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::PhysicalExamOrder";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/PhysicalExamPerformed.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/PhysicalExamPerformed.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.Code;
@@ -54,6 +56,8 @@ public class PhysicalExamPerformed extends DataElement {
   private String qdmCategory = "physical_exam";
   private String qdmStatus = "performed";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::PhysicalExamPerformed";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/PhysicalExamRecommended.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/PhysicalExamRecommended.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -40,6 +42,8 @@ public class PhysicalExamRecommended extends DataElement {
   private String qdmCategory = "physical_exam";
   private String qdmStatus = "recommended";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::PhysicalExamRecommended";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/ProcedureOrder.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/ProcedureOrder.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -42,6 +44,8 @@ public class ProcedureOrder extends DataElement {
   private String qdmCategory = "procedure";
   private String qdmStatus = "order";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::ProcedureOrder";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/ProcedurePerformed.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/ProcedurePerformed.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.Code;
@@ -63,6 +65,8 @@ public class ProcedurePerformed extends DataElement {
   private String qdmCategory = "procedure";
   private String qdmStatus = "performed";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::ProcedurePerformed";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/ProcedureRecommended.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/ProcedureRecommended.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -41,6 +43,8 @@ public class ProcedureRecommended extends DataElement {
   private String qdmCategory = "procedure";
   private String qdmStatus = "recommended";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::ProcedureRecommended";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/ProviderCareExperience.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/ProviderCareExperience.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -35,6 +37,8 @@ public class ProviderCareExperience extends DataElement {
   private String hqmfOid = "2.16.840.1.113883.10.20.28.4.70";
   private String qdmCategory = "care_experience";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::ProviderCareExperience";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/RelatedPerson.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/RelatedPerson.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Identifier;
 import lombok.AllArgsConstructor;
@@ -18,6 +20,8 @@ public class RelatedPerson extends DataElement {
   private String hqmfOid = "2.16.840.1.113883.10.20.28.4.141";
   private String qdmCategory = "related_person";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::RelatedPerson";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/SubstanceAdministered.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/SubstanceAdministered.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.Code;
@@ -50,6 +52,8 @@ public class SubstanceAdministered extends DataElement {
   private String qdmCategory = "substance";
   private String qdmStatus = "administered";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::SubstanceAdministered";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/SubstanceOrder.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/SubstanceOrder.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.Code;
@@ -47,6 +49,8 @@ public class SubstanceOrder extends DataElement {
   private String qdmCategory = "substance";
   private String qdmStatus = "order";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::SubstanceOrder";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/SubstanceRecommended.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/SubstanceRecommended.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.LocalDateTimeFormatConstant;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
@@ -44,6 +46,8 @@ public class SubstanceRecommended extends DataElement {
   private String qdmCategory = "substance";
   private String qdmStatus = "recommended";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::SubstanceRecommended";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/Symptom.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/Symptom.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import gov.cms.madie.models.cqm.datacriteria.basetypes.DataElement;
 import gov.cms.madie.models.cqm.datacriteria.attributes.Entity;
 import gov.cms.madie.models.cqm.datacriteria.basetypes.Code;
@@ -24,6 +26,8 @@ public class Symptom extends DataElement {
   private String qrdaOid = "2.16.840.1.113883.10.20.24.3.136";
   private String qdmCategory = "symptom";
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::Symptom";
 
   public void shiftDates(int shifted) {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/attributes/FacilityLocation.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/attributes/FacilityLocation.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria.attributes;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import org.springframework.format.annotation.DateTimeFormat;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -29,5 +31,7 @@ public class FacilityLocation implements Attribute {
   private Interval locationPeriod;
 
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::FacilityLocation";
 }

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/attributes/Identifier.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/attributes/Identifier.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria.attributes;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,6 +15,8 @@ public class Identifier implements Attribute {
   private String namingSystem;
   private String value;
   private String qdmVersion = "5.6";
+
+  @JsonProperty("_type")
   private String _type = "QDM::Identifier";
 
   // CQM validates uniqueness of value with conditions

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/basetypes/Component.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/basetypes/Component.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria.basetypes;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import lombok.AllArgsConstructor;
@@ -14,8 +16,13 @@ import lombok.NoArgsConstructor;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Component {
   private String qdmVersion;
+
+  @JsonProperty("_type")
   private String _type;
+
+  @JsonProperty("_id")
   private String _id;
+
   private Code code;
 
   private Object result;

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/basetypes/DataElement.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/basetypes/DataElement.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria.basetypes;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
@@ -116,6 +118,7 @@ public class DataElement {
   private String desc;
   private String codeId;
 
+  @JsonProperty("_id")
   private String _id;
 
   public void shiftDates(int shifted) throws ShiftDatesException {

--- a/src/main/java/gov/cms/madie/models/cqm/datacriteria/basetypes/TestCaseJson.java
+++ b/src/main/java/gov/cms/madie/models/cqm/datacriteria/basetypes/TestCaseJson.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.cqm.datacriteria.basetypes;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -23,7 +25,9 @@ import lombok.Setter;
 @Setter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TestCaseJson {
+  @JsonProperty("_id")
   private String _id;
+
   private String qdmVersion = "5.6";
   private List<DataElement> dataElements;
 

--- a/src/main/java/gov/cms/madie/models/library/CqlLibrary.java
+++ b/src/main/java/gov/cms/madie/models/library/CqlLibrary.java
@@ -1,7 +1,7 @@
 package gov.cms.madie.models.library;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
 
 import gov.cms.madie.models.common.IncludedLibrary;
 import gov.cms.madie.models.validators.EnumValidator;

--- a/src/main/java/gov/cms/madie/models/measure/Measure.java
+++ b/src/main/java/gov/cms/madie/models/measure/Measure.java
@@ -25,8 +25,8 @@ import org.springframework.data.mongodb.core.index.Indexed;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
 
 import gov.cms.madie.models.common.ModelType;
 import gov.cms.madie.models.common.Version;

--- a/src/main/java/gov/cms/madie/models/measure/TestCase.java
+++ b/src/main/java/gov/cms/madie/models/measure/TestCase.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.models.measure;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import lombok.AllArgsConstructor;
@@ -66,7 +68,10 @@ public class TestCase implements Serializable, Cloneable {
   private HapiOperationOutcome hapiOperationOutcome;
 
   @Valid private List<TestCaseGroupPopulation> groupPopulations;
+
+  @JsonProperty("bundleTypeUpdated")
   private boolean isBundleTypeUpdated;
+
   private String validationStatus;
   private String validationTaskId;
 

--- a/src/main/java/gov/cms/madie/models/utils/VersionJsonSerializer.java
+++ b/src/main/java/gov/cms/madie/models/utils/VersionJsonSerializer.java
@@ -1,37 +1,33 @@
 package gov.cms.madie.models.utils;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-
 import gov.cms.madie.models.common.Version;
-
-import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.jackson.JsonComponent;
+import org.springframework.boot.jackson.JacksonComponent;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.ValueSerializer;
 
 @Slf4j
-@JsonComponent
+@JacksonComponent
 public class VersionJsonSerializer {
 
-  public static class VersionSerializer extends JsonSerializer<Version> {
+  public static class VersionSerializer extends ValueSerializer<Version> {
     @Override
-    public void serialize(Version value, JsonGenerator gen, SerializerProvider serializers)
-        throws IOException {
+    public void serialize(Version value, JsonGenerator gen, SerializationContext serializers) {
       gen.writeString(value == null ? null : value.toString());
     }
   }
 
-  public static class VersionDeserializer extends JsonDeserializer<Version> {
+  public static class VersionDeserializer extends ValueDeserializer<Version> {
     @Override
     public Version deserialize(JsonParser jp, DeserializationContext ctxt) {
       try {
-        JsonNode node = jp.getCodec().readTree(jp);
-        return Version.parse(node.asText());
+        JsonNode node = ctxt.readTree(jp);
+        return Version.parse(node.isValueNode() ? node.asString() : "");
       } catch (Exception ex) {
         log.error("An error occurred while deserializing the version", ex);
       }

--- a/src/test/java/gov/cms/madie/models/MeasurePopulationTest.java
+++ b/src/test/java/gov/cms/madie/models/MeasurePopulationTest.java
@@ -2,15 +2,15 @@ package gov.cms.madie.models;
 
 import gov.cms.madie.models.measure.PopulationType;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class MeasurePopulationTest {
   @Test
   public void testPopulationToCode() {
-    Assert.assertEquals(PopulationType.INITIAL_POPULATION.toCode(), "initial-population");
+    Assertions.assertEquals(PopulationType.INITIAL_POPULATION.toCode(), "initial-population");
     assertEquals(PopulationType.NUMERATOR.toCode(), "numerator");
     assertEquals(PopulationType.NUMERATOR_EXCLUSION.toCode(), "numerator-exclusion");
     assertEquals(PopulationType.DENOMINATOR.toCode(), "denominator");

--- a/src/test/java/gov/cms/madie/models/common/ModelTypeTest.java
+++ b/src/test/java/gov/cms/madie/models/common/ModelTypeTest.java
@@ -14,7 +14,7 @@ public class ModelTypeTest {
     assertThat(ModelType.QI_CORE_6_0_0.getVersionNumber(), is(equalTo("6.0.0")));
     assertThat(ModelType.QI_CORE_7_0_0.getVersionNumber(), is(equalTo("7.0.0")));
     assertThat(ModelType.QI_CORE_7_0_2.getVersionNumber(), is(equalTo("7.0.2")));
-    assertThat(ModelType.US_CORE_6_0_1.getVersionNumber(), is(equalTo("6.1.0")));
+    assertThat(ModelType.US_CORE_6_1_0.getVersionNumber(), is(equalTo("6.1.0")));
     assertThat(ModelType.US_QUALITY_CORE_0_5_0.getVersionNumber(), is(equalTo("0.5.0")));
   }
 }

--- a/src/test/java/gov/cms/madie/models/common/ModelTypeTest.java
+++ b/src/test/java/gov/cms/madie/models/common/ModelTypeTest.java
@@ -14,7 +14,7 @@ public class ModelTypeTest {
     assertThat(ModelType.QI_CORE_6_0_0.getVersionNumber(), is(equalTo("6.0.0")));
     assertThat(ModelType.QI_CORE_7_0_0.getVersionNumber(), is(equalTo("7.0.0")));
     assertThat(ModelType.QI_CORE_7_0_2.getVersionNumber(), is(equalTo("7.0.2")));
-    assertThat(ModelType.US_CORE_6_0_1.getVersionNumber(), is(equalTo("6.0.1")));
+    assertThat(ModelType.US_CORE_6_0_1.getVersionNumber(), is(equalTo("6.1.0")));
     assertThat(ModelType.US_QUALITY_CORE_0_5_0.getVersionNumber(), is(equalTo("0.5.0")));
   }
 }

--- a/src/test/java/gov/cms/madie/models/validators/MeasureScoringValidatorTest.java
+++ b/src/test/java/gov/cms/madie/models/validators/MeasureScoringValidatorTest.java
@@ -14,9 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import gov.cms.madie.models.measure.BaseConfigurationTypes;
 import gov.cms.madie.models.measure.MeasureScoring;
@@ -99,8 +97,7 @@ public class MeasureScoringValidatorTest {
   }
 
   @Test
-  public void testDeserializeInvalidBaseConfigurationTypesThrowsException()
-      throws JsonMappingException, JsonProcessingException {
+  public void testDeserializeInvalidBaseConfigurationTypesThrowsException() {
     String qdmMeasureStr =
         "{\n"
             + "    \"model\": \"QDM v5.6\",\n"
@@ -117,7 +114,7 @@ public class MeasureScoringValidatorTest {
     ObjectMapper mapper = new ObjectMapper();
 
     assertThrows(
-        com.fasterxml.jackson.databind.exc.InvalidFormatException.class,
+        tools.jackson.databind.exc.InvalidFormatException.class,
         () -> mapper.readValue(qdmMeasureStr, QdmMeasure.class));
   }
 

--- a/src/test/java/gov/cms/madie/models/validators/RequiredByOtherFieldValidatorTest.java
+++ b/src/test/java/gov/cms/madie/models/validators/RequiredByOtherFieldValidatorTest.java
@@ -10,9 +10,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
 class RequiredByOtherFieldValidatorTest {
 
   private final RequiredByOtherFieldValidator validator = new RequiredByOtherFieldValidator();


### PR DESCRIPTION
## MADiE PR Template

Jira Ticket: [MAT-10132](https://jira.cms.gov/browse/MAT-10132)
(Optional) Related Tickets:

### Summary

# Spring Boot 4 + Jackson 3 Upgrade Notes — madie-java-models

Part of the fleet-wide SB 3.5.14 → 4.0.6 + Jackson 2 → 3 migration. Common patterns live in
`madie-fhir-service/SPRING_BOOT_4_UPGRADE.md`; this file records only what was specific to this repo.

This library is the **linchpin** of the Jackson 3 migration: it owns `VersionJsonSerializer`, the custom
(de)serializer on `Measure.version` / `CqlLibrary.version`. It must be built and published before any
consumer can move to Jackson 3.

## Version
`0.9.6-SNAPSHOT` → **`0.10.0-SNAPSHOT`**

## pom.xml
- `springboot.version` `3.5.14` → `4.0.6`.
- **BOM-less library** → added the `spring-boot-dependencies:${springboot.version}` BOM import in
  `<dependencyManagement>` (manages Spring Framework 7 + Jackson 3 versions).
- Jackson 2 → 3 coordinates: `jackson-databind` group `com.fasterxml.jackson.core` → `tools.jackson.core`
  (version dropped, BOM-managed); `jackson-annotations` **stays** on `com.fasterxml.jackson.core`
  (BOM-managed). Removed the `fasterxml.jackson.version` property.
- Added `org.springframework.boot:spring-boot-jackson` — provides `@JacksonComponent`, which the basic
  `spring-boot-starter` does not pull transitively.
- `maven-surefire-plugin` `2.22.1` → **`3.5.2`** (see Test infra below).

## Source — Jackson 3 API changes
- `VersionJsonSerializer`: `JsonSerializer` → `tools.jackson.databind.ValueSerializer`; `JsonDeserializer`
  → `ValueDeserializer`; `SerializerProvider` → `SerializationContext`; `JsonGenerator`/`JsonParser` →
  `tools.jackson.core`; inside the deserializer `jp.getCodec().readTree(jp)` (removed in Jackson 3) →
  `ctxt.readTree(jp)`; `@JsonComponent` → `@JacksonComponent`; dropped `throws IOException` (Jackson 3
  exceptions are unchecked).
- `Measure.java` / `CqlLibrary.java`: the databind-level `@JsonSerialize` / `@JsonDeserialize` imports
  moved `com.fasterxml.jackson.databind.annotation.*` → `tools.jackson.databind.annotation.*`. The ~90
  core annotations elsewhere (`@JsonProperty`, `@JsonFormat`, `@JsonTypeInfo`, etc.) are unchanged —
  jackson-annotations keeps the `com.fasterxml.jackson.annotation` package.

## Test infrastructure
- The old pinned `maven-surefire-plugin:2.22.1` cannot launch under the JUnit Platform 6.x that the SB4
  BOM pulls in (`NoClassDefFoundError: PreconditionViolationException`) → bumped to `3.5.2`.
- **Side effect worth knowing:** with surefire 2.22.1 + `junit:junit` on the classpath, surefire selected
  the JUnit 4 provider and **silently skipped all JUnit 5 Jupiter `@Test` methods**. Bumping surefire
  makes them run for the first time, which surfaced two latent issues unrelated to Jackson:
  - `ModelTypeTest` asserted US Core `"6.0.1"` while MAT-10030 (commit ffb0815) had changed the enum to
    return `"6.1.0"` — the test had never executed. Fixed the assertion to `"6.1.0"`.
  - `RequiredByOtherFieldValidatorTest` used `@ExtendWith(SpringExtension.class)` with `@Mock` fields;
    SB4 removed `MockitoTestExecutionListener`, so the mocks were null → switched to `MockitoExtension`.
- Converted the one remaining JUnit 4 test (`MeasurePopulationTest`) to JUnit 5.
- `MeasureScoringValidatorTest`: `ObjectMapper` → `tools.jackson.databind`; dropped the now-unchecked
  `throws` clause; `InvalidFormatException` → `tools.jackson.databind.exc`.

## ⚠️ Deserializer gotcha (Jackson 3 strict node coercion)
`VersionDeserializer` originally did `Version.parse(node.asText())`. **Jackson 3's `asText()`/`asString()`
is strict** — it throws `JsonNodeException` on a non-scalar node, whereas Jackson 2 leniently returned
`""`. Some consumer fixtures store `version` as an object `{major,minor,revisionNumber}` (not a string),
so under Jackson 3 the deserializer threw, was caught, and returned `null` → downstream
`NullPointerException` on `Measure.getVersion()`. Restored the Jackson-2 lenient behavior explicitly:
`Version.parse(node.isValueNode() ? node.asString() : "")` (a non-scalar node → `""` →
`Version.parse("")` → `new Version()`, exactly as before). This surfaced only when fhir-service ran its
real Measure-deserialization tests against the Jackson-3 lib — java-models' own unit tests did not cover
the object-form fixture.

## Result
`mvn clean install` green — 153 tests. Installed to local `~/.m2` (publish to GitHub Packages at cutover).


### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e. Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
